### PR TITLE
switch pyaudio out for mpv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML==6.0.2
-PyAudio~=0.2.14
 comtypes~=1.4.6
+mpv~=1.0.7

--- a/src/main.py
+++ b/src/main.py
@@ -1,27 +1,18 @@
 import re
 import yaml
 import time
-import pyaudio
-import wave
+import mpv
 import tempfile
 import os
 import tts
 
 class Audio:
     def __init__(self):
-        self.audio = pyaudio.PyAudio()
+        self.audio = mpv.MPV()
 
     def play_sound(self, path):
-        with wave.open(path, 'rb') as output:
-            stream = self.audio.open(format=self.audio.get_format_from_width(output.getsampwidth()),
-                                     channels=output.getnchannels(),
-                                     rate=output.getframerate(),
-                                     output=True)
-
-            while len(data := output.readframes(1024)):
-                stream.write(data)
-
-            stream.close()
+        self.audio.play(path)
+        self.audio.wait_for_playback()
 
 def load_config(file):
     with open(file) as f:


### PR DESCRIPTION
no commas in this one actually

for future reference, my pyaudio rant from #dev-whining:

> PORTAUDIO REVIEW:
it just
`OSError: [Errno -9997] Invalid sample rate`
does this sometimes on linux
with no way to fix it
google search leads me nowhere
duckduckgo search leads me nowhere
bing search leads me nowhere
I'm the only person with this issue
but if i switch it to use mpv
i can probably package that in the sapphone executable
it'll work better cross platform
It Can Play Anything
but i dont know what performance impact it would have
TO BE FAIR: i dont think anyone is running this on a computer where resource usage of a minecraft tts app is a concern